### PR TITLE
Added method to load commands dynamically

### DIFF
--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -174,41 +174,9 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
 	{
 		return array_merge(
 			parent::getDefaultCommands(),
-            $this->loadCommands()
+            []
 		);
 	}
-
-    /**
-     * Dynamically Load Commands from  JPATH_LIBRARIES/src/Console/
-     *
-     * @return array
-     *
-     * @since 4.0.0
-     */
-    private function loadCommands() : array
-    {
-        $root = JPATH_LIBRARIES . '/src/';
-        $paths = glob($root . 'Console/*.php');
-
-        foreach ($paths as $key => $path) {
-            $namespaces[]  = str_replace(
-                ['.php', DIRECTORY_SEPARATOR],
-                ['', '\\'],
-                explode($root, $path)[1]
-            );
-        }
-
-        if (empty($namespaces)) {
-            return [];
-        } else {
-            foreach ($namespaces as $key => $command) {
-                $command = '\Joomla\CMS\\' . $command;
-                $commands[] =  (new  \ReflectionClass($command))->newInstance();
-            }
-        }
-
-        return $commands;
-    }
 
 	/**
 	 * Retrieve the application configuration object.

--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -174,13 +174,41 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
 	{
 		return array_merge(
 			parent::getDefaultCommands(),
-			[
-				new Console\CleanCacheCommand,
-				new Console\CheckUpdatesCommand,
-				new Console\RemoveOldFilesCommand,
-			]
+            $this->loadCommands()
 		);
 	}
+
+    /**
+     * Dynamically Load Commands from  JPATH_LIBRARIES/src/Console/
+     *
+     * @return array
+     *
+     * @since 4.0.0
+     */
+    private function loadCommands() : array
+    {
+        $root = JPATH_LIBRARIES . '/src/';
+        $paths = glob($root . 'Console/*.php');
+
+        foreach ($paths as $key => $path) {
+            $namespaces[]  = str_replace(
+                ['.php', DIRECTORY_SEPARATOR],
+                ['', '\\'],
+                explode($root, $path)[1]
+            );
+        }
+
+        if (empty($namespaces)) {
+            return [];
+        } else {
+            foreach ($namespaces as $key => $command) {
+                $command = '\Joomla\CMS\\' . $command;
+                $commands[] =  (new  \ReflectionClass($command))->newInstance();
+            }
+        }
+
+        return $commands;
+    }
 
 	/**
 	 * Retrieve the application configuration object.

--- a/libraries/src/Console/SessionGcCommand.php
+++ b/libraries/src/Console/SessionGcCommand.php
@@ -31,16 +31,21 @@ class SessionGcCommand extends AbstractCommand
 	/**
 	 * Instantiate the command.
 	 *
+	 * Having a constructor here doesn't follow the way other commands are written
+	 * and its disturbing the Dynamic way of loading the commands as its requiring argument to be passed to
+	 * constructor
+	 *
 	 * @param   SessionInterface  $session  The session object.
 	 *
 	 * @since   4.0.0
 	 */
-	public function __construct(SessionInterface $session)
-	{
-		$this->session = $session;
+//	public function __construct(SessionInterface $session)
+//	{
+//		$this->session = $session;
+//
+//		parent::__construct();
+//	}
 
-		parent::__construct();
-	}
 
 	/**
 	 * Execute the command.

--- a/libraries/src/Console/SessionGcCommand.php
+++ b/libraries/src/Console/SessionGcCommand.php
@@ -31,20 +31,16 @@ class SessionGcCommand extends AbstractCommand
 	/**
 	 * Instantiate the command.
 	 *
-	 * Having a constructor here doesn't follow the way other commands are written
-	 * and its disturbing the Dynamic way of loading the commands as its requiring argument to be passed to
-	 * constructor
-	 *
 	 * @param   SessionInterface  $session  The session object.
 	 *
 	 * @since   4.0.0
 	 */
-//	public function __construct(SessionInterface $session)
-//	{
-//		$this->session = $session;
-//
-//		parent::__construct();
-//	}
+	public function __construct(SessionInterface $session)
+	{
+		$this->session = $session;
+
+		parent::__construct();
+	}
 
 
 	/**

--- a/libraries/src/Service/Provider/Application.php
+++ b/libraries/src/Service/Provider/Application.php
@@ -106,6 +106,22 @@ class Application implements ServiceProviderInterface
 					$app->setLogger($container->get(LoggerInterface::class));
 					$app->setSession($session);
 
+					// Dynamically register core commands
+					$srcDir = JPATH_LIBRARIES . '/src/';
+					$paths = glob($srcDir . '/Console/*.php');
+
+					foreach ($paths as $key => $path) {
+						$namespaces[] = str_replace(
+							['.php', DIRECTORY_SEPARATOR],
+							['', '\\'],
+							explode($srcDir, $path)[1]
+						);
+					}
+					foreach ($namespaces as $key => $command) {
+							$className = '\Joomla\CMS' . $command;
+							$app->addCommand($container->buildSharedObject($className));
+					}
+
 					return $app;
 				},
 				true
@@ -119,7 +135,6 @@ class Application implements ServiceProviderInterface
 					$mapping = [
 						'session:gc' => SessionGcCommand::class,
 					];
-
 					return new ContainerLoader($container, $mapping);
 				},
 				true


### PR DESCRIPTION
Pull Request for Issue #1  .

### Summary of Changes
Added a method inside libraries/src/Application/ConsoleApplication.php to make loading of commands dynamic.


### Testing Instructions
Add a command class inside  libraries/src/Console/ and it should be loaded as a command when you run `php cli/joomla.php` 


### Expected result
Commands are loaded


### Actual result
Commands are Loaded

