### PR TITLE
Removed custom_data and system_data

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2017-10-10.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2017-10-10.sql
@@ -1,5 +1,5 @@
-INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `custom_data`, `system_data`, `checked_out`, `checked_out_time`, `ordering`, `state`) VALUES
-(487, 'plg_system_httpheaders', 'plugin', 'httpheaders', 'system', 0, 0, 1, 0, '', '{}', '', '', 0, '0000-00-00 00:00:00', 0, 0);
+INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `checked_out`, `checked_out_time`, `ordering`, `state`) VALUES
+(487, 'plg_system_httpheaders', 'plugin', 'httpheaders', 'system', 0, 0, 1, 0, '', '{}', 0, '0000-00-00 00:00:00', 0, 0);
 
 INSERT INTO `#__postinstall_messages` (`extension_id`, `title_key`, `description_key`, `action_key`, `language_extension`, `language_client_id`, `type`, `action_file`, `action`, `condition_file`, `condition_method`, `version_introduced`, `enabled`)
 VALUES

--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-06-11.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-06-11.sql
@@ -1,4 +1,4 @@
 INSERT INTO `#__extensions`
-(`extension_id`, `package_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `custom_data`, `system_data`, `checked_out`, `checked_out_time`, `ordering`, `state`)
+(`extension_id`, `package_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `checked_out`, `checked_out_time`, `ordering`, `state`)
 VALUES
-  (488, 0, 'plg_sampledata_multilang', 'plugin', 'multilang', 'sampledata', 0, 0, 1, 0, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0);
+  (488, 0, 'plg_sampledata_multilang', 'plugin', 'multilang', 'sampledata', 0, 0, 1, 0, '', '', 0, '0000-00-00 00:00:00', 0, 0);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Removed `custom_data` and `system_data` fields from 4.0 sql files which were causing errors like: 

`[Joomla\Database\Exception\PrepareStatementFailureException]  
  Unknown column 'custom_data' in 'field list'` 

This error is thrown during Joomla core update, the columns `custom_data` and `system_data` were removed from extensions table [here](https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_admin/sql/updates/mysql/4.0.0-2017-03-18.sql)