### PR TITLE
Milestone five

### DIFF
--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -184,6 +184,7 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
 				new Console\ExtensionInstallCommand,
 				new Console\ExtensionRemoveCommand,
 				new Console\CheckJoomlaUpdatesCommand,
+				new Console\GetConfigurationCommand,
 			]
 		);
 	}

--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -185,6 +185,7 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
 				new Console\ExtensionRemoveCommand,
 				new Console\CheckJoomlaUpdatesCommand,
 				new Console\GetConfigurationCommand,
+				new Console\SetConfigurationCommand,
 			]
 		);
 	}

--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -12,7 +12,6 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Console;
 use Joomla\CMS\Extension\ExtensionManagerTrait;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Version;
 use Joomla\Input\Cli;
 use Joomla\CMS\Plugin\PluginHelper;
@@ -186,6 +185,8 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
 				new Console\CheckJoomlaUpdatesCommand,
 				new Console\GetConfigurationCommand,
 				new Console\SetConfigurationCommand,
+				new Console\SiteDownCommand,
+				new Console\SiteUpCommand,
 			]
 		);
 	}

--- a/libraries/src/Console/GetConfigurationCommand.php
+++ b/libraries/src/Console/GetConfigurationCommand.php
@@ -12,10 +12,8 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\Console\AbstractCommand;
 use Symfony\Component\Console\Input\Input;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Joomla\CMS\Factory;
 
 /**
  * Console command for displaying configuration options
@@ -51,6 +49,7 @@ class GetConfigurationCommand extends AbstractCommand
 		$this->ioStyle = new SymfonyStyle($this->getApplication()->getConsoleInput(), $this->getApplication()->getConsoleOutput());
 	}
 
+
 	/**
 	 * Execute the command.
 	 *
@@ -61,8 +60,132 @@ class GetConfigurationCommand extends AbstractCommand
 	public function execute(): int
 	{
 		$this->configureIO();
-		$option = $this->cliInput->getArgument('option');
 
+		$configs = $this->formatConfig($this->getApplication()->getConfig()->toArray());
+
+		$option = $this->cliInput->getArgument('option');
+		$group = $this->cliInput->getOption('group');
+
+		if ($group)
+		{
+			return $this->processGroupOptions($group);
+		}
+
+		if ($option)
+		{
+			return $this->processSingleOption($option);
+		}
+
+		if (!$option && !$group)
+		{
+			$options = [];
+			array_walk($configs, function ($value, $key) use (&$options) {
+					$options[] = [$key, $value];
+			    }
+			);
+
+			$this->ioStyle->title("Current options in Configuration");
+			$this->ioStyle->table(['Option', 'Value'], $options);
+
+			return 0;
+		}
+
+		return 1;
+	}
+
+	/**
+	 * Displays logically grouped options
+	 *
+	 * @param   string  $group  The group to be processed
+	 *
+	 * @return integer
+	 *
+	 * @since 4.0
+	 */
+	public function processGroupOptions($group)
+	{
+		$configs = $this->getApplication()->getConfig()->toArray();
+		$configs = $this->formatConfig($configs);
+
+		switch ($group)
+		{
+			case 'db':
+				$options[] = ['dbtype', $configs['dbtype']];
+				$options[] = ['host', $configs['host']];
+				$options[] = ['user', $configs['user']];
+				$options[] = ['password', $configs['password']];
+				$options[] = ['db', $configs['db']];
+				$options[] = ['dbprefix', $configs['dbprefix']];
+				break;
+
+			case 'mail':
+				$options[] = ['mailonline', $configs['mailonline']];
+				$options[] = ['mailer', $configs['mailer']];
+				$options[] = ['mailfrom', $configs['mailfrom']];
+				$options[] = ['fromname', $configs['fromname']];
+				$options[] = ['sendmail', $configs['sendmail']];
+				$options[] = ['smtpauth', $configs['smtpauth']];
+				$options[] = ['smtpuser', $configs['smtpuser']];
+				$options[] = ['smtppass', $configs['smtppass']];
+				$options[] = ['smtphost', $configs['smtphost']];
+				$options[] = ['smtpsecure', $configs['smtpsecure']];
+				$options[] = ['smtpport', $configs['smtpport']];
+				break;
+
+			case 'session':
+				$options[] = ['session_handler', $configs['session_handler']];
+				$options[] = ['shared_session', $configs['shared_session']];
+				$options[] = ['session_metadata', $configs['session_metadata']];
+				break;
+
+			default:
+				$this->ioStyle->error('Group not found, available groups are: db, mail, session');
+
+				return 1;
+				break;
+		}
+
+		$this->ioStyle->table(['Option', 'Value'], $options);
+
+		return 0;
+	}
+
+	/**
+	 * Formats the configuration array into desired format
+	 *
+	 * @param   array  $configs  Array of the configurations
+	 *
+	 * @return array
+	 *
+	 * @since 4.0
+	 */
+	public function formatConfig($configs)
+	{
+		foreach ($configs as $key => $config)
+		{
+			$config = $config === false ? "false" : $config;
+			$config = $config === true ? "true" : $config;
+
+			if (!in_array($key, ['cwd', 'execution']))
+			{
+				$newConfig[$key] = $config;
+			}
+ 		}
+
+		return $newConfig;
+	}
+
+	/**
+	 * Handles the command when an single option is requested
+	 *
+	 * @param   string  $option  The option we want to get its value
+	 *
+	 * @return integer
+	 *
+	 * @since 4.0
+	 */
+	public function processSingleOption($option)
+	{
 		$configs = $this->getApplication()->getConfig()->toArray();
 
 		if (!array_key_exists($option, $configs))
@@ -91,7 +214,8 @@ class GetConfigurationCommand extends AbstractCommand
 		$this->setName('config:get');
 		$this->setDescription('Displays the current value of a configuration option');
 
-		$this->addArgument('option', InputArgument::REQUIRED, 'Name of the option');
+		$this->addArgument('option', null, 'Name of the option');
+		$this->addOption('group', 'g', InputOption::VALUE_REQUIRED, 'Name of the option');
 
 		$help = "The <info>%command.name%</info> Displays the current value of a configuration option
 				\nUsage: <info>php %command.full_name%</info> <option>";

--- a/libraries/src/Console/GetConfigurationCommand.php
+++ b/libraries/src/Console/GetConfigurationCommand.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Console;
+
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\Console\AbstractCommand;
+use Symfony\Component\Console\Input\Input;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Joomla\CMS\Factory;
+
+/**
+ * Console command for checking if there are pending extension updates
+ *
+ * @since  4.0.0
+ */
+class GetConfigurationCommand extends AbstractCommand
+{
+	/**
+	 * Stores the Input Object
+	 * @var Input
+	 * @since 4.0
+	 */
+	private $cliInput;
+
+	/**
+	 * SymfonyStyle Object
+	 * @var SymfonyStyle
+	 * @since 4.0
+	 */
+	private $ioStyle;
+
+	/**
+	 * Configures the IO
+	 *
+	 * @return void
+	 *
+	 * @since 4.0
+	 */
+	private function configureIO()
+	{
+		$this->cliInput = $this->getApplication()->getConsoleInput();
+		$this->ioStyle = new SymfonyStyle($this->getApplication()->getConsoleInput(), $this->getApplication()->getConsoleOutput());
+	}
+
+	/**
+	 * Execute the command.
+	 *
+	 * @return  integer  The exit code for the command.
+	 *
+	 * @since   4.0.0
+	 */
+	public function execute(): int
+	{
+		$this->configureIO();
+		$option = $this->cliInput->getArgument('option');
+
+		$configs = Factory::getConfig()->toArray();
+
+		if (!array_key_exists($option, $configs))
+		{
+			$this->ioStyle->error("Can't find option *$option* in configuration list");
+
+			return 1;
+		}
+
+		$value = $this->getApplication()->get($option) ?: 'Not set';
+
+		$this->ioStyle->table(['Option', 'Value'], [[$option, $value]]);
+
+		return 0;
+	}
+
+	/**
+	 * Initialise the command.
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0.0
+	 */
+	protected function initialise()
+	{
+		$this->setName('config:get');
+		$this->setDescription('List installed extensions');
+
+		$this->addArgument('option', InputArgument::REQUIRED, 'Name of the option');
+
+		$help = "The <info>%command.name%</info> Displays the current value of a configuration option
+				\nUsage: <info>php %command.full_name%</info> <option>";
+
+		$this->setHelp($help);
+	}
+}

--- a/libraries/src/Console/GetConfigurationCommand.php
+++ b/libraries/src/Console/GetConfigurationCommand.php
@@ -63,7 +63,7 @@ class GetConfigurationCommand extends AbstractCommand
 		$this->configureIO();
 		$option = $this->cliInput->getArgument('option');
 
-		$configs = Factory::getConfig()->toArray();
+		$configs = $this->getApplication()->getConfig()->toArray();
 
 		if (!array_key_exists($option, $configs))
 		{
@@ -89,7 +89,7 @@ class GetConfigurationCommand extends AbstractCommand
 	protected function initialise()
 	{
 		$this->setName('config:get');
-		$this->setDescription('List installed extensions');
+		$this->setDescription('Displays the current value of a configuration option');
 
 		$this->addArgument('option', InputArgument::REQUIRED, 'Name of the option');
 

--- a/libraries/src/Console/GetConfigurationCommand.php
+++ b/libraries/src/Console/GetConfigurationCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Joomla\CMS\Factory;
 
 /**
- * Console command for checking if there are pending extension updates
+ * Console command for displaying configuration options
  *
  * @since  4.0.0
  */

--- a/libraries/src/Console/GetConfigurationCommand.php
+++ b/libraries/src/Console/GetConfigurationCommand.php
@@ -37,6 +37,27 @@ class GetConfigurationCommand extends AbstractCommand
 	private $ioStyle;
 
 	/**
+	 * Constant defining the Database option group
+	 * @var array
+	 * @since 4.0
+	 */
+	const DB_GROUP = ['name' => 'db', 'options' => ['dbtype', 'host', 'user', 'password', 'dbprefix', 'db']];
+
+	/**
+	 * Constant defining the Session option group
+	 * @var array
+	 * @since 4.0
+	 */
+	const SESSION_GROUP = ['name' => 'session', 'options' => ['session_handler', 'shared_session', 'session_metadata']];
+
+	/**
+	 * Constant defining the Mail option group
+	 * @var array
+	 * @since 4.0
+	 */
+	const MAIL_GROUP = ['name' => 'mail', 'options' => ['mailonline', 'mailer', 'mailfrom', 'fromname', 'sendmail', 'smtpauth', 'smtpuser', 'smtppass', 'smtphost', 'smtpsecure', 'smtpport']];
+
+	/**
 	 * Configures the IO
 	 *
 	 * @return void
@@ -109,47 +130,47 @@ class GetConfigurationCommand extends AbstractCommand
 		$configs = $this->getApplication()->getConfig()->toArray();
 		$configs = $this->formatConfig($configs);
 
-		switch ($group)
+		$groups = $this->getGroups();
+
+		$foundGroup = false;
+
+		foreach ($groups as $key => $value)
 		{
-			case 'db':
-				$options[] = ['dbtype', $configs['dbtype']];
-				$options[] = ['host', $configs['host']];
-				$options[] = ['user', $configs['user']];
-				$options[] = ['password', $configs['password']];
-				$options[] = ['db', $configs['db']];
-				$options[] = ['dbprefix', $configs['dbprefix']];
-				break;
-
-			case 'mail':
-				$options[] = ['mailonline', $configs['mailonline']];
-				$options[] = ['mailer', $configs['mailer']];
-				$options[] = ['mailfrom', $configs['mailfrom']];
-				$options[] = ['fromname', $configs['fromname']];
-				$options[] = ['sendmail', $configs['sendmail']];
-				$options[] = ['smtpauth', $configs['smtpauth']];
-				$options[] = ['smtpuser', $configs['smtpuser']];
-				$options[] = ['smtppass', $configs['smtppass']];
-				$options[] = ['smtphost', $configs['smtphost']];
-				$options[] = ['smtpsecure', $configs['smtpsecure']];
-				$options[] = ['smtpport', $configs['smtpport']];
-				break;
-
-			case 'session':
-				$options[] = ['session_handler', $configs['session_handler']];
-				$options[] = ['shared_session', $configs['shared_session']];
-				$options[] = ['session_metadata', $configs['session_metadata']];
-				break;
-
-			default:
-				$this->ioStyle->error('Group not found, available groups are: db, mail, session');
-
-				return 1;
-				break;
+			if ($value['name'] === $group)
+			{
+				$foundGroup = true;
+				$options = [];
+				foreach ($value['options'] as $key => $option)
+				{
+					$options[] = [$option, $configs[$option]];
+				}
+				$this->ioStyle->table(['Option', 'Value'], $options);
+			}
 		}
 
-		$this->ioStyle->table(['Option', 'Value'], $options);
+		if (!$foundGroup)
+		{
+			$this->ioStyle->error("Group *$group* not found");
+			exit;
+		}
 
 		return 0;
+	}
+
+	/**
+	 * Gets the defined option groups
+	 *
+	 * @return array
+	 *
+	 * @since 4.0
+	 */
+	public function getGroups()
+	{
+		return [
+				self::DB_GROUP,
+				self::MAIL_GROUP,
+				self::SESSION_GROUP
+		];
 	}
 
 	/**

--- a/libraries/src/Console/GetConfigurationCommand.php
+++ b/libraries/src/Console/GetConfigurationCommand.php
@@ -100,6 +100,7 @@ class GetConfigurationCommand extends AbstractCommand
 		if (!$option && !$group)
 		{
 			$options = [];
+
 			array_walk(
 				$configs,
 				function ($value, $key) use (&$options) {
@@ -140,10 +141,12 @@ class GetConfigurationCommand extends AbstractCommand
 			{
 				$foundGroup = true;
 				$options = [];
+
 				foreach ($value['options'] as $key => $option)
 				{
 					$options[] = [$option, $configs[$option]];
 				}
+
 				$this->ioStyle->table(['Option', 'Value'], $options);
 			}
 		}
@@ -235,6 +238,7 @@ class GetConfigurationCommand extends AbstractCommand
 	protected function initialise()
 	{
 		$groups = $this->getGroups();
+
 		foreach ($groups as $key => $group)
 		{
 			$groupNames[] = $group['name'];

--- a/libraries/src/Console/GetConfigurationCommand.php
+++ b/libraries/src/Console/GetConfigurationCommand.php
@@ -234,6 +234,14 @@ class GetConfigurationCommand extends AbstractCommand
 	 */
 	protected function initialise()
 	{
+		$groups = $this->getGroups();
+		foreach ($groups as $key => $group)
+		{
+			$groupNames[] = $group['name'];
+		}
+
+		$groupNames = implode(', ', $groupNames);
+
 		$this->setName('config:get');
 		$this->setDescription('Displays the current value of a configuration option');
 
@@ -241,7 +249,9 @@ class GetConfigurationCommand extends AbstractCommand
 		$this->addOption('group', 'g', InputOption::VALUE_REQUIRED, 'Name of the option');
 
 		$help = "The <info>%command.name%</info> Displays the current value of a configuration option
-				\nUsage: <info>php %command.full_name%</info> <option>";
+				\nUsage: <info>php %command.full_name%</info> <option>
+				\nGroup usage: <info>php %command.full_name%</info> --group=<groupname>
+				\nAvailable group names: $groupNames";
 
 		$this->setHelp($help);
 	}

--- a/libraries/src/Console/GetConfigurationCommand.php
+++ b/libraries/src/Console/GetConfigurationCommand.php
@@ -79,7 +79,9 @@ class GetConfigurationCommand extends AbstractCommand
 		if (!$option && !$group)
 		{
 			$options = [];
-			array_walk($configs, function ($value, $key) use (&$options) {
+			array_walk(
+				$configs,
+				function ($value, $key) use (&$options) {
 					$options[] = [$key, $value];
 			    }
 			);

--- a/libraries/src/Console/GetConfigurationCommand.php
+++ b/libraries/src/Console/GetConfigurationCommand.php
@@ -55,7 +55,15 @@ class GetConfigurationCommand extends AbstractCommand
 	 * @var array
 	 * @since 4.0
 	 */
-	const MAIL_GROUP = ['name' => 'mail', 'options' => ['mailonline', 'mailer', 'mailfrom', 'fromname', 'sendmail', 'smtpauth', 'smtpuser', 'smtppass', 'smtphost', 'smtpsecure', 'smtpport']];
+	const MAIL_GROUP = [
+				'name' => 'mail',
+				'options' => [
+					'mailonline', 'mailer', 'mailfrom',
+					'fromname', 'sendmail', 'smtpauth',
+					'smtpuser', 'smtppass', 'smtphost',
+					'smtpsecure', 'smtpport'
+				]
+	];
 
 	/**
 	 * Configures the IO
@@ -105,7 +113,7 @@ class GetConfigurationCommand extends AbstractCommand
 				$configs,
 				function ($value, $key) use (&$options) {
 					$options[] = [$key, $value];
-			    }
+				}
 			);
 
 			$this->ioStyle->title("Current options in Configuration");
@@ -196,7 +204,7 @@ class GetConfigurationCommand extends AbstractCommand
 			{
 				$newConfig[$key] = $config;
 			}
- 		}
+		}
 
 		return $newConfig;
 	}

--- a/libraries/src/Console/SetConfigurationCommand.php
+++ b/libraries/src/Console/SetConfigurationCommand.php
@@ -79,7 +79,7 @@ class SetConfigurationCommand extends AbstractCommand
 		$value = $value === 'false' ? false : $value;
 		$value = $value === 'true' ? true : $value;
 
-		$config->set($option, (boolean) $value);
+		$config->set($option, $value);
 		$config->remove('cwd');
 		$config->remove('execution');
 		$buffer = $config->toString('PHP', array('class' => 'JConfig', 'closingtag' => false));

--- a/libraries/src/Console/SetConfigurationCommand.php
+++ b/libraries/src/Console/SetConfigurationCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Joomla\CMS\Factory;
 
 /**
- * Console command for checking if there are pending extension updates
+ * Console command Setting Configuration options
  *
  * @since  4.0.0
  */

--- a/libraries/src/Console/SetConfigurationCommand.php
+++ b/libraries/src/Console/SetConfigurationCommand.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Console;
+
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\Console\AbstractCommand;
+use Symfony\Component\Console\Input\Input;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Joomla\CMS\Factory;
+
+/**
+ * Console command for checking if there are pending extension updates
+ *
+ * @since  4.0.0
+ */
+class SetConfigurationCommand extends AbstractCommand
+{
+	/**
+	 * Stores the Input Object
+	 * @var Input
+	 * @since 4.0
+	 */
+	private $cliInput;
+
+	/**
+	 * SymfonyStyle Object
+	 * @var SymfonyStyle
+	 * @since 4.0
+	 */
+	private $ioStyle;
+
+	/**
+	 * Configures the IO
+	 *
+	 * @return void
+	 *
+	 * @since 4.0
+	 */
+	private function configureIO()
+	{
+		$this->cliInput = $this->getApplication()->getConsoleInput();
+		$this->ioStyle = new SymfonyStyle($this->getApplication()->getConsoleInput(), $this->getApplication()->getConsoleOutput());
+	}
+
+	/**
+	 * Execute the command.
+	 *
+	 * @return  integer  The exit code for the command.
+	 *
+	 * @since   4.0.0
+	 */
+	public function execute(): int
+	{
+		$this->configureIO();
+
+		$option = $this->cliInput->getArgument('option');
+
+		$config = $this->getApplication()->getConfig();
+
+		$configs = $config->toArray();
+
+		if (!array_key_exists($option, $configs))
+		{
+			$this->ioStyle->error("Can't find option *$option* in configuration list");
+
+			return 1;
+		}
+
+		$value = $this->cliInput->getArgument('value');
+		$value = $value === 'false' ? false : $value;
+		$value = $value === 'true' ? true : $value;
+
+		$config->set($option, (boolean) $value);
+		$config->remove('cwd');
+		$config->remove('execution');
+		$buffer = $config->toString('PHP', array('class' => 'JConfig', 'closingtag' => false));
+
+		$path = JPATH_CONFIGURATION . '/configuration.php';
+
+		if ($this->writeFile($buffer, $path))
+		{
+			$this->ioStyle->success('Configuration set');
+
+			return 0;
+		}
+
+		return 2;
+	}
+
+	/**
+	 * Initialise the command.
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0.0
+	 */
+	protected function initialise()
+	{
+		$this->setName('config:set');
+		$this->setDescription('Sets a value for a configuration option');
+
+		$this->addArgument('option', InputArgument::REQUIRED, 'Name of the option');
+		$this->addArgument('value', InputArgument::REQUIRED, 'Value of the option');
+
+		$help = "The <info>%command.name%</info> Sets a value for a configuration option
+				\nUsage: <info>php %command.full_name%</info> <option> <value>";
+
+		$this->setHelp($help);
+	}
+
+	/**
+	 * Writes a string to a given file path
+	 *
+	 * @param   string  $buffer  The string that will be written to the file
+	 * @param   string  $path    The path to write the file
+	 *
+	 * @return boolean
+	 *
+	 * @since 4.0
+	 */
+	public function writeFile($buffer, $path)
+	{
+		// Determine if the configuration file path is writable.
+		if (file_exists($path))
+		{
+			$canWrite = is_writable($path);
+		}
+		else
+		{
+			$canWrite = is_writable(JPATH_CONFIGURATION . '/');
+		}
+
+		/*
+		 * If the file exists but isn't writable OR if the file doesn't exist and the parent directory
+		 * is not writable we need to use FTP.
+		 */
+		$useFTP = false;
+
+		if ((file_exists($path) && !is_writable($path)) || (!file_exists($path) && !is_writable(dirname($path) . '/')))
+		{
+			return false;
+		}
+
+		// Check for safe mode.
+		if (ini_get('safe_mode'))
+		{
+			$useFTP = true;
+		}
+
+		// Enable/Disable override.
+		if (!isset($options->ftpEnable) || ($options->ftpEnable != 1))
+		{
+			$useFTP = false;
+		}
+
+		if ($canWrite)
+		{
+			file_put_contents($path, $buffer);
+		}
+		else
+		{
+			// If we cannot write the configuration.php, setup fails!
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/libraries/src/Console/SetConfigurationCommand.php
+++ b/libraries/src/Console/SetConfigurationCommand.php
@@ -49,6 +49,31 @@ class SetConfigurationCommand extends AbstractCommand
 	 */
 	private $options;
 
+
+	/**
+	 * Return code if configuration is set successfully
+	 * @since 4.0
+	 */
+	const CONFIG_SET_SUCCESSFUL = 0;
+
+	/**
+	 * Return code if configuration set failed
+	 * @since 4.0
+	 */
+	const CONFIG_SET_FAILED = 3;
+
+	/**
+	 * Return code if database validation failed
+	 * @since 4.0
+	 */
+	const DB_VALIDATION_FAILED = 1;
+
+	/**
+	 * Return code if config validation failed
+	 * @since 4.0
+	 */
+	const CONFIG_VALIDATION_FAILED = 2;
+
 	/**
 	 * Configures the IO
 	 *
@@ -150,7 +175,7 @@ class SetConfigurationCommand extends AbstractCommand
 
 		if (!$options)
 		{
-			return 2;
+			return self::CONFIG_VALIDATION_FAILED;
 		}
 
 
@@ -161,7 +186,7 @@ class SetConfigurationCommand extends AbstractCommand
 
 		if ($db === false)
 		{
-			return 1;
+			return self::DB_VALIDATION_FAILED;
 		}
 
 
@@ -169,10 +194,10 @@ class SetConfigurationCommand extends AbstractCommand
 		{
 			$this->ioStyle->success('Configuration set');
 
-			return 0;
+			return self::CONFIG_SET_SUCCESSFUL;
 		}
 
-		return 3;
+		return self::CONFIG_SET_FAILED;
 	}
 
 

--- a/libraries/src/Console/SetConfigurationCommand.php
+++ b/libraries/src/Console/SetConfigurationCommand.php
@@ -24,7 +24,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * Console command Setting Configuration options
  *
- * @since 4.0.0
+ * @since  4.0.0
  */
 class SetConfigurationCommand extends AbstractCommand
 {
@@ -431,7 +431,7 @@ class SetConfigurationCommand extends AbstractCommand
 			}
 		}
 
-	    // Build the connection options array.
+		// Build the connection options array.
 		$settings = [
 			'driver'   => $options->db_type,
 			'host'     => $options->db_host,

--- a/libraries/src/Console/SetConfigurationCommand.php
+++ b/libraries/src/Console/SetConfigurationCommand.php
@@ -28,242 +28,281 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 class SetConfigurationCommand extends AbstractCommand
 {
-    /**
-     * Stores the Input Object
-     * @var Input
-     * @since 4.0
-     */
-    private $cliInput;
+	/**
+	 * Stores the Input Object
+	 * @var Input
+	 * @since 4.0
+	 */
+	private $cliInput;
 
-    /**
-     * SymfonyStyle Object
-     * @var SymfonyStyle
-     * @since 4.0
-     */
-    private $ioStyle;
+	/**
+	 * SymfonyStyle Object
+	 * @var SymfonyStyle
+	 * @since 4.0
+	 */
+	private $ioStyle;
 
-    /**
-     * Configures the IO
-     *
-     * @return void
-     *
-     * @since 4.0
-     */
-    private function configureIO()
-    {
-	    $language = Factory::getLanguage();
-	    $language->load('', JPATH_INSTALLATION, null, false, false) ||
-	    $language->load('', JPATH_INSTALLATION, null, true);
-        $this->cliInput = $this->getApplication()->getConsoleInput();
-        $this->ioStyle = new SymfonyStyle($this->getApplication()->getConsoleInput(), $this->getApplication()->getConsoleOutput());
-    }
+	/**
+	 * Options Array
+	 * @var array
+	 * @since 4.0
+	 */
+	private $options;
 
-
-    /**
-     * Collects options from user input
-     *
-     * @param array $options Options inputed by users
-     *
-     * @return array
-     *
-     * @since 4.0
-     */
-    public function retrieveOptionsFromInput($options)
-    {
-        $collected = [];
-
-        foreach ($options as $option)
-        {
-            if (strpos($option, '=') === false)
-            {
-                $this->ioStyle
-                    ->error('Options and values should be separated by "="');
-                exit;
-            }
-
-            list($option, $value) = explode('=', $option);
-
-            $collected[$option] = $value;
-        }
-
-        return $collected;
-    }
+	/**
+	 * Configures the IO
+	 *
+	 * @return void
+	 *
+	 * @since 4.0
+	 */
+	private function configureIO()
+	{
+		$language = Factory::getLanguage();
+		$language->load('', JPATH_INSTALLATION, null, false, false) ||
+		$language->load('', JPATH_INSTALLATION, null, true);
+		$this->cliInput = $this->getApplication()->getConsoleInput();
+		$this->ioStyle = new SymfonyStyle($this->getApplication()->getConsoleInput(), $this->getApplication()->getConsoleOutput());
+	}
 
 
-    /**
-     * Validates the options provided
-     *
-     * @param array $options Options Array
-     *
-     * @return mixed
-     *
-     * @since 4.0
-     */
-    public function validateOptions($options)
-    {
-        $config = $this->getApplication()->getConfig();
+	/**
+	 * Collects options from user input
+	 *
+	 * @param array $options Options inputed by users
+	 *
+	 * @return array
+	 *
+	 * @since 4.0
+	 */
+	public function retrieveOptionsFromInput($options)
+	{
+	    $collected = [];
 
-        $configs = $config->toArray();
-
-        array_walk(
-            $options, function ($value, $key) use ($configs) {
-                if (!array_key_exists($key, $configs))
-                {
-                    $this->getApplication()
-                        ->enqueueMessage(
-                            "Can't find option *$key* in configuration list",
-                            'error'
-                        );
-                }
-        });
-
-        return $options;
-    }
-
-    /**
-     * Execute the command.
-     *
-     * @return integer The exit code for the command.
-     *
-     * @since 4.0
-     *
-     * @throws void
-     */
-    public function execute(): int
-    {
-        $this->configureIO();
-
-        $options = $this->cliInput->getArgument('options');
-
-        $options = $this->retrieveOptionsFromInput($options);
-
-        $options = $this->validateOptions($options);
-
-
-	    if (!$options)
+	    foreach ($options as $option)
 	    {
-		    return 2;
+	        if (strpos($option, '=') === false)
+	        {
+	            $this->ioStyle
+	                ->error('Options and values should be separated by "="');
+	            exit;
+	        }
+
+	        list($option, $value) = explode('=', $option);
+
+	        $collected[$option] = $value;
 	    }
 
-
-	    $initialOptions = $this->getApplication()->getConfig()->toArray();
-	    $combinedOptions = array_merge($initialOptions, $options);
-
-	    $db = $this->checkDb($combinedOptions);
-
-	    if ($db === false)
-        {
-            return 1;
-        }
+	    return $collected;
+	}
 
 
-        if ($this->saveConfiguration($options))
-        {
-            $this->ioStyle->success('Configuration set');
+	/**
+	 * Validates the options provided
+	 *
+	 * @param array $options Options Array
+	 *
+	 * @return mixed
+	 *
+	 * @since 4.0
+	 */
+	public function validateOptions($options)
+	{
+		$config = $this->getApplication()->getConfig();
 
-            return 0;
-        }
+		$configs = $config->toArray();
 
-        return 3;
-    }
+		array_walk(
+		    $options, function ($value, $key) use ($configs) {
+		        if (!array_key_exists($key, $configs))
+		        {
+		            $this->getApplication()
+		                ->enqueueMessage(
+		                    "Can't find option *$key* in configuration list",
+		                    'error'
+		                );
+		        }
+		});
+
+		return $options;
+	}
+
+	/**
+	 * Execute the command.
+	 *
+	 * @return integer The exit code for the command.
+	 *
+	 * @since 4.0
+	 *
+	 * @throws void
+	 */
+	public function execute(): int
+	{
+		$this->configureIO();
+
+		$options = $this->getOptions();
+
+		$options = $this->retrieveOptionsFromInput($options);
+
+		$options = $this->validateOptions($options);
 
 
-    /**
-     * Save the configuration file
-     *
-     * @param array $options Collected options
-     *
-     * @return bool
-     *
-     * @since 4.0
-     */
-    public function saveConfiguration($options)
-    {
-        $config = $this->getApplication()->getConfig();
+		if (!$options)
+		{
+			return 2;
+		}
 
-        foreach ($options as $key => $value)
-        {
-            $value = $value === 'false' ? false : $value;
-            $value = $value === 'true' ? true : $value;
 
-            $config->set($key, $value);
-        }
+		$initialOptions = $this->getApplication()->getConfig()->toArray();
+		$combinedOptions = array_merge($initialOptions, $options);
 
-        $config->remove('cwd');
-        $config->remove('execution');
-        $buffer = $config->toString(
-            'PHP',
-            array('class' => 'JConfig', 'closingtag' => false)
-        );
+		$db = $this->checkDb($combinedOptions);
 
-        $path = JPATH_CONFIGURATION . '/configuration.php';
+		if ($db === false)
+		{
+			return 1;
+		}
 
-        if ($this->writeFile($buffer, $path))
-        {
-            return true;
-        }
 
-        return false;
-    }
+		if ($this->saveConfiguration($options))
+		{
+			$this->ioStyle->success('Configuration set');
 
-    /**
-     * Initialise the command.
-     *
-     * @return void
-     *
-     * @since 4.0
-     */
-    protected function initialise()
-    {
-        $this->setName('config:set');
-        $this->setDescription('Sets a value for a configuration option');
+			return 0;
+		}
 
-        $this->addArgument(
-            'options',
-            InputArgument::REQUIRED | InputArgument::IS_ARRAY,
-            'All options you want to set'
-        );
+		return 3;
+	}
 
-        $help = "The <info>%command.name%</info> 
-                  Sets a value for a configuration option
-                \nUsage: <info>php %command.full_name%</info> <option> <value>";
 
-        $this->setHelp($help);
-    }
+	/**
+	 * Sets the options array
+	 *
+	 * @param   string  $options  Options string
+	 *
+	 * @since 4.0
+	 *
+	 * @return void
+	 */
+	public function setOptions($options)
+	{
+		$this->options = explode(' ', $options);
+	}
 
-    /**
-     * Writes a string to a given file path
-     *
-     * @param string $buffer The string that will be written to the file
-     * @param string $path   The path to write the file
-     *
-     * @return boolean
-     *
-     * @since 4.0
-     */
-    public function writeFile($buffer, $path)
-    {
-        $options = $this->getApplication()->getConfig();
-        // Determine if the configuration file path is writable.
-        if (file_exists($path))
-        {
-            $canWrite = is_writable($path);
-        }
-        else
-        {
-            $canWrite = is_writable(JPATH_CONFIGURATION . '/');
-        }
+	/**
+	 * Collects the options array
+	 *
+	 * @return array|mixed
+	 *
+	 * @since 4.0
+	 */
+	public function getOptions()
+	{
+		if ($this->options)
+		{
+			return $this->options;
+		}
 
-        /*
-         * If the file exists but isn't writable OR if the file doesn't exist and the parent directory
-         * is not writable we need to use FTP.
-         */
-        $useFTP = false;
+		return $this->cliInput->getArgument('options');
+	}
 
-        if ((file_exists($path) && !is_writable($path)) || (!file_exists($path) && !is_writable(dirname($path) . '/')))
-        {
-            return false;
-        }
+
+	/**
+	 * Save the configuration file
+	 *
+	 * @param   array  $options  Collected options
+	 *
+	 * @return boolean
+	 *
+	 * @since 4.0
+	 */
+	public function saveConfiguration($options)
+	{
+	    $config = $this->getApplication()->getConfig();
+
+	    foreach ($options as $key => $value)
+	    {
+	        $value = $value === 'false' ? false : $value;
+	        $value = $value === 'true' ? true : $value;
+
+	        $config->set($key, $value);
+	    }
+
+	    $config->remove('cwd');
+	    $config->remove('execution');
+	    $buffer = $config->toString(
+	        'PHP',
+	        array('class' => 'JConfig', 'closingtag' => false)
+	    );
+
+	    $path = JPATH_CONFIGURATION . '/configuration.php';
+
+	    if ($this->writeFile($buffer, $path))
+	    {
+	        return true;
+	    }
+
+	    return false;
+	}
+
+	/**
+	 * Initialise the command.
+	 *
+	 * @return void
+	 *
+	 * @since 4.0
+	 */
+	protected function initialise()
+	{
+	    $this->setName('config:set');
+	    $this->setDescription('Sets a value for a configuration option');
+
+	    $this->addArgument(
+	        'options',
+	        InputArgument::REQUIRED | InputArgument::IS_ARRAY,
+	        'All options you want to set'
+	    );
+
+	    $help = "The <info>%command.name%</info> 
+	              Sets a value for a configuration option
+	            \nUsage: <info>php %command.full_name%</info> <option> <value>";
+
+	    $this->setHelp($help);
+	}
+
+	/**
+	 * Writes a string to a given file path
+	 *
+	 * @param string $buffer The string that will be written to the file
+	 * @param string $path   The path to write the file
+	 *
+	 * @return boolean
+	 *
+	 * @since 4.0
+	 */
+	public function writeFile($buffer, $path)
+	{
+	    $options = $this->getApplication()->getConfig();
+	    // Determine if the configuration file path is writable.
+	    if (file_exists($path))
+	    {
+	        $canWrite = is_writable($path);
+	    }
+	    else
+	    {
+	        $canWrite = is_writable(JPATH_CONFIGURATION . '/');
+	    }
+
+	    /*
+	     * If the file exists but isn't writable OR if the file doesn't exist and the parent directory
+	     * is not writable we need to use FTP.
+	     */
+	    $useFTP = false;
+
+	    if ((file_exists($path) && !is_writable($path)) || (!file_exists($path) && !is_writable(dirname($path) . '/')))
+	    {
+	        return false;
+	    }
 
 		// Check for safe mode.
 		if (ini_get('safe_mode'))
@@ -292,8 +331,8 @@ class SetConfigurationCommand extends AbstractCommand
 
 
 	/**
-     * Verifies database connection
-     *
+	 * Verifies database connection
+	 *
 	 * @param $options
 	 *
 	 * @return bool|\Joomla\Database\DatabaseInterface
@@ -303,14 +342,14 @@ class SetConfigurationCommand extends AbstractCommand
 	 */
 	public function checkDb($options)
 	{
-        $options = [
-            'db_type' => $options['dbtype'],
-            'db_host' => $options['host'],
-            'db_prefix' => $options['dbprefix'],
-            'db_name' => $options['db'],
-            'db_pass' => $options['password'],
-            'db_user' => $options['user'],
-        ];
+	    $options = [
+	        'db_type' => $options['dbtype'],
+	        'db_host' => $options['host'],
+	        'db_prefix' => $options['dbprefix'],
+	        'db_name' => $options['db'],
+	        'db_pass' => $options['password'],
+	        'db_user' => $options['user'],
+	    ];
 
 
 		// Get the options as an object for easier handling.
@@ -390,32 +429,32 @@ class SetConfigurationCommand extends AbstractCommand
 			}
 		}
 
-        // Build the connection options array.
-        $settings = [
-            'driver'   => $options->db_type,
-            'host'     =>  $options->db_host,
-            'user'     =>  $options->db_user,
-            'password' => $options->db_pass,
-            'database' => $options->db_name,
-            'prefix'   => $options->db_prefix,
-            'select'   => isset($options->db_select) ? $options->db_select : false
-        ];
+	    // Build the connection options array.
+	    $settings = [
+	        'driver'   => $options->db_type,
+	        'host'     =>  $options->db_host,
+	        'user'     =>  $options->db_user,
+	        'password' => $options->db_pass,
+	        'database' => $options->db_name,
+	        'prefix'   => $options->db_prefix,
+	        'select'   => isset($options->db_select) ? $options->db_select : false
+	    ];
 
-        // Get a database object.
+	    // Get a database object.
 
 
-        // Get a database object.
-        try
-        {
-            return DatabaseDriver::getInstance($settings)->connect();
-        }
-        catch (\RuntimeException $e)
-        {
-            Factory::getApplication()->enqueueMessage(
-                Text::sprintf('Cannot connect to database, verify that you specified the correct database details', null),
-                'error');
+	    // Get a database object.
+	    try
+	    {
+	        return DatabaseDriver::getInstance($settings)->connect();
+	    }
+	    catch (\RuntimeException $e)
+	    {
+	        Factory::getApplication()->enqueueMessage(
+	            Text::sprintf('Cannot connect to database, verify that you specified the correct database details', null),
+	            'error');
 
-            return false;
-        }
+	        return false;
+	    }
 	}
 }

--- a/libraries/src/Console/SetConfigurationCommand.php
+++ b/libraries/src/Console/SetConfigurationCommand.php
@@ -70,9 +70,10 @@ class SetConfigurationCommand extends AbstractCommand
     {
         $collected = [];
 
-        foreach ($options as $option) {
-
-            if (strpos($option, '=') === false) {
+        foreach ($options as $option)
+        {
+            if (strpos($option, '=') === false)
+            {
                 $this->ioStyle
                     ->error('Options and values should be separated by "="');
                 exit;
@@ -104,7 +105,8 @@ class SetConfigurationCommand extends AbstractCommand
 
         array_walk(
             $options, function ($value, $key) use ($configs) {
-                if (!array_key_exists($key, $configs)) {
+                if (!array_key_exists($key, $configs))
+                {
                     $this->getApplication()
                         ->enqueueMessage(
                             "Can't find option *$key* in configuration list",
@@ -140,15 +142,18 @@ class SetConfigurationCommand extends AbstractCommand
 
         $db = $this->checkDb($combinedOptions);
 
-        if (!$options) {
+        if (!$options)
+        {
             return 2;
         }
 
-        if (!$db) {
+        if (!$db)
+        {
             return 1;
         }
 
-        if ($this->saveConfiguration($options)) {
+        if ($this->saveConfiguration($options))
+        {
             $this->ioStyle->success('Configuration set');
 
             return 0;
@@ -170,7 +175,8 @@ class SetConfigurationCommand extends AbstractCommand
     {
         $config = $this->getApplication()->getConfig();
 
-        foreach ($options as $key => $value) {
+        foreach ($options as $key => $value)
+        {
             $value = $value === 'false' ? false : $value;
             $value = $value === 'true' ? true : $value;
 
@@ -186,7 +192,8 @@ class SetConfigurationCommand extends AbstractCommand
 
         $path = JPATH_CONFIGURATION . '/configuration.php';
 
-        if ($this->writeFile($buffer, $path)) {
+        if ($this->writeFile($buffer, $path))
+        {
             return true;
         }
 
@@ -232,9 +239,12 @@ class SetConfigurationCommand extends AbstractCommand
     {
         $options = $this->getApplication()->getConfig();
         // Determine if the configuration file path is writable.
-        if (file_exists($path)) {
+        if (file_exists($path))
+        {
             $canWrite = is_writable($path);
-        } else {
+        }
+        else
+        {
             $canWrite = is_writable(JPATH_CONFIGURATION . '/');
         }
 
@@ -333,8 +343,6 @@ class SetConfigurationCommand extends AbstractCommand
 
 			return false;
 		}
-//		var_dump($options);
-//		exit;
 
 		// Ensure that a database name was input.
 		if (empty($options->db_name))

--- a/libraries/src/Console/SetConfigurationCommand.php
+++ b/libraries/src/Console/SetConfigurationCommand.php
@@ -129,6 +129,7 @@ class SetConfigurationCommand extends AbstractCommand
 	 */
 	public function writeFile($buffer, $path)
 	{
+	    $options = $this->getApplication()->getConfig();
 		// Determine if the configuration file path is writable.
 		if (file_exists($path))
 		{

--- a/libraries/src/Console/SetConfigurationCommand.php
+++ b/libraries/src/Console/SetConfigurationCommand.php
@@ -69,7 +69,7 @@ class SetConfigurationCommand extends AbstractCommand
 	/**
 	 * Collects options from user input
 	 *
-	 * @param array $options Options inputed by users
+	 * @param   array  $options  Options inputed by users
 	 *
 	 * @return array
 	 *
@@ -77,30 +77,30 @@ class SetConfigurationCommand extends AbstractCommand
 	 */
 	public function retrieveOptionsFromInput($options)
 	{
-	    $collected = [];
+		$collected = [];
 
-	    foreach ($options as $option)
-	    {
-	        if (strpos($option, '=') === false)
-	        {
-	            $this->ioStyle
-	                ->error('Options and values should be separated by "="');
-	            exit;
-	        }
+		foreach ($options as $option)
+		{
+			if (strpos($option, '=') === false)
+			{
+				$this->ioStyle
+					->error('Options and values should be separated by "="');
+				exit;
+			}
 
-	        list($option, $value) = explode('=', $option);
+			list($option, $value) = explode('=', $option);
 
-	        $collected[$option] = $value;
-	    }
+			$collected[$option] = $value;
+		}
 
-	    return $collected;
+		return $collected;
 	}
 
 
 	/**
 	 * Validates the options provided
 	 *
-	 * @param array $options Options Array
+	 * @param   array  $options  Options Array
 	 *
 	 * @return mixed
 	 *
@@ -113,16 +113,17 @@ class SetConfigurationCommand extends AbstractCommand
 		$configs = $config->toArray();
 
 		array_walk(
-		    $options, function ($value, $key) use ($configs) {
-		        if (!array_key_exists($key, $configs))
-		        {
-		            $this->getApplication()
-		                ->enqueueMessage(
-		                    "Can't find option *$key* in configuration list",
-		                    'error'
-		                );
-		        }
-		});
+			$options, function ($value, $key) use ($configs) {
+				if (!array_key_exists($key, $configs))
+				{
+					$this->getApplication()
+						->enqueueMessage(
+							"Can't find option *$key* in configuration list",
+							'error'
+						);
+				}
+			}
+		);
 
 		return $options;
 	}
@@ -218,31 +219,31 @@ class SetConfigurationCommand extends AbstractCommand
 	 */
 	public function saveConfiguration($options)
 	{
-	    $config = $this->getApplication()->getConfig();
+		$config = $this->getApplication()->getConfig();
 
-	    foreach ($options as $key => $value)
-	    {
-	        $value = $value === 'false' ? false : $value;
-	        $value = $value === 'true' ? true : $value;
+		foreach ($options as $key => $value)
+		{
+			$value = $value === 'false' ? false : $value;
+			$value = $value === 'true' ? true : $value;
 
-	        $config->set($key, $value);
-	    }
+			$config->set($key, $value);
+		}
 
-	    $config->remove('cwd');
-	    $config->remove('execution');
-	    $buffer = $config->toString(
-	        'PHP',
-	        array('class' => 'JConfig', 'closingtag' => false)
-	    );
+		$config->remove('cwd');
+		$config->remove('execution');
+		$buffer = $config->toString(
+			'PHP',
+			array('class' => 'JConfig', 'closingtag' => false)
+		);
 
-	    $path = JPATH_CONFIGURATION . '/configuration.php';
+		$path = JPATH_CONFIGURATION . '/configuration.php';
 
-	    if ($this->writeFile($buffer, $path))
-	    {
-	        return true;
-	    }
+		if ($this->writeFile($buffer, $path))
+		{
+			return true;
+		}
 
-	    return false;
+		return false;
 	}
 
 	/**
@@ -254,27 +255,27 @@ class SetConfigurationCommand extends AbstractCommand
 	 */
 	protected function initialise()
 	{
-	    $this->setName('config:set');
-	    $this->setDescription('Sets a value for a configuration option');
+		$this->setName('config:set');
+		$this->setDescription('Sets a value for a configuration option');
 
-	    $this->addArgument(
-	        'options',
-	        InputArgument::REQUIRED | InputArgument::IS_ARRAY,
-	        'All options you want to set'
-	    );
+		$this->addArgument(
+			'options',
+			InputArgument::REQUIRED | InputArgument::IS_ARRAY,
+			'All options you want to set'
+		);
 
-	    $help = "The <info>%command.name%</info> 
-	              Sets a value for a configuration option
-	            \nUsage: <info>php %command.full_name%</info> <option> <value>";
+		$help = "The <info>%command.name%</info> 
+				Sets a value for a configuration option
+				\nUsage: <info>php %command.full_name%</info> <option> <value>";
 
-	    $this->setHelp($help);
+		$this->setHelp($help);
 	}
 
 	/**
 	 * Writes a string to a given file path
 	 *
-	 * @param string $buffer The string that will be written to the file
-	 * @param string $path   The path to write the file
+	 * @param   string  $buffer  The string that will be written to the file
+	 * @param   string  $path    The path to write the file
 	 *
 	 * @return boolean
 	 *
@@ -282,27 +283,28 @@ class SetConfigurationCommand extends AbstractCommand
 	 */
 	public function writeFile($buffer, $path)
 	{
-	    $options = $this->getApplication()->getConfig();
-	    // Determine if the configuration file path is writable.
-	    if (file_exists($path))
-	    {
-	        $canWrite = is_writable($path);
-	    }
-	    else
-	    {
-	        $canWrite = is_writable(JPATH_CONFIGURATION . '/');
-	    }
+		$options = $this->getApplication()->getConfig();
 
-	    /*
-	     * If the file exists but isn't writable OR if the file doesn't exist and the parent directory
-	     * is not writable we need to use FTP.
-	     */
-	    $useFTP = false;
+		// Determine if the configuration file path is writable.
+		if (file_exists($path))
+		{
+			$canWrite = is_writable($path);
+		}
+		else
+		{
+			$canWrite = is_writable(JPATH_CONFIGURATION . '/');
+		}
 
-	    if ((file_exists($path) && !is_writable($path)) || (!file_exists($path) && !is_writable(dirname($path) . '/')))
-	    {
-	        return false;
-	    }
+		/*
+		* If the file exists but isn't writable OR if the file doesn't exist and the parent directory
+		* is not writable we need to use FTP.
+		*/
+		$useFTP = false;
+
+		if ((file_exists($path) && !is_writable($path)) || (!file_exists($path) && !is_writable(dirname($path) . '/')))
+		{
+			return false;
+		}
 
 		// Check for safe mode.
 		if (ini_get('safe_mode'))
@@ -333,7 +335,7 @@ class SetConfigurationCommand extends AbstractCommand
 	/**
 	 * Verifies database connection
 	 *
-	 * @param $options
+	 * @param   array  $options  Options array
 	 *
 	 * @return bool|\Joomla\Database\DatabaseInterface
 	 *
@@ -342,14 +344,14 @@ class SetConfigurationCommand extends AbstractCommand
 	 */
 	public function checkDb($options)
 	{
-	    $options = [
-	        'db_type' => $options['dbtype'],
-	        'db_host' => $options['host'],
-	        'db_prefix' => $options['dbprefix'],
-	        'db_name' => $options['db'],
-	        'db_pass' => $options['password'],
-	        'db_user' => $options['user'],
-	    ];
+		$options = [
+			'db_type' => $options['dbtype'],
+			'db_host' => $options['host'],
+			'db_prefix' => $options['dbprefix'],
+			'db_name' => $options['db'],
+			'db_pass' => $options['password'],
+			'db_user' => $options['user'],
+		];
 
 
 		// Get the options as an object for easier handling.
@@ -430,31 +432,29 @@ class SetConfigurationCommand extends AbstractCommand
 		}
 
 	    // Build the connection options array.
-	    $settings = [
-	        'driver'   => $options->db_type,
-	        'host'     =>  $options->db_host,
-	        'user'     =>  $options->db_user,
-	        'password' => $options->db_pass,
-	        'database' => $options->db_name,
-	        'prefix'   => $options->db_prefix,
-	        'select'   => isset($options->db_select) ? $options->db_select : false
-	    ];
+		$settings = [
+			'driver'   => $options->db_type,
+			'host'     => $options->db_host,
+			'user'     => $options->db_user,
+			'password' => $options->db_pass,
+			'database' => $options->db_name,
+			'prefix'   => $options->db_prefix,
+			'select'   => isset($options->db_select) ? $options->db_select : false
+		];
 
-	    // Get a database object.
+		// Get a database object.
+		try
+		{
+			return DatabaseDriver::getInstance($settings)->connect();
+		}
+		catch (\RuntimeException $e)
+		{
+			Factory::getApplication()->enqueueMessage(
+				Text::sprintf('Cannot connect to database, verify that you specified the correct database details', null),
+				'error'
+			);
 
-
-	    // Get a database object.
-	    try
-	    {
-	        return DatabaseDriver::getInstance($settings)->connect();
-	    }
-	    catch (\RuntimeException $e)
-	    {
-	        Factory::getApplication()->enqueueMessage(
-	            Text::sprintf('Cannot connect to database, verify that you specified the correct database details', null),
-	            'error');
-
-	        return false;
-	    }
+			return false;
+		}
 	}
 }

--- a/libraries/src/Console/SetConfigurationCommand.php
+++ b/libraries/src/Console/SetConfigurationCommand.php
@@ -192,7 +192,7 @@ class SetConfigurationCommand extends AbstractCommand
 
 		if ($this->saveConfiguration($options))
 		{
-			$this->ioStyle->success('Configuration set');
+			$this->options ?: $this->ioStyle->success('Configuration set');
 
 			return self::CONFIG_SET_SUCCESSFUL;
 		}

--- a/libraries/src/Console/SiteDownCommand.php
+++ b/libraries/src/Console/SiteDownCommand.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Console;
+
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\Console\AbstractCommand;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Console command wrapper for getting the site into offline mode
+ *
+ * @since  4.0.0
+ */
+class SiteDownCommand extends AbstractCommand
+{
+	/**
+	 * SymfonyStyle Object
+	 * @var SymfonyStyle
+	 * @since 4.0
+	 */
+	private $ioStyle;
+
+	/**
+	 * Configures the IO
+	 *
+	 * @return void
+	 *
+	 * @since 4.0
+	 */
+	private function configureIO()
+	{
+		$this->ioStyle = new SymfonyStyle($this->getApplication()->getConsoleInput(), $this->getApplication()->getConsoleOutput());
+	}
+
+	/**
+	 * Execute the command.
+	 *
+	 * @return  integer  The exit code for the command.
+	 *
+	 * @since   4.0.0
+	 */
+	public function execute(): int
+	{
+		$this->configureIO();
+
+		exec('php cli/joomla.php config:set offline true', $parts);
+		$output = implode("\n", $parts);
+
+		if (strpos($output, "Configuration set") !== false)
+		{
+			$this->ioStyle->success("Successfully set site to offline");
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Initialise the command.
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0.0
+	 */
+	protected function initialise()
+	{
+		$this->setName('site:down');
+		$this->setDescription('Puts the site into offline mode');
+
+		$help = "The <info>%command.name%</info> Puts the site into offline mode
+				\nUsage: <info>php %command.full_name%</info>";
+
+		$this->setHelp($help);
+	}
+}

--- a/libraries/src/Console/SiteDownCommand.php
+++ b/libraries/src/Console/SiteDownCommand.php
@@ -50,15 +50,21 @@ class SiteDownCommand extends AbstractCommand
 	{
 		$this->configureIO();
 
-		exec('php cli/joomla.php config:set offline=true', $parts);
-		$output = implode("\n", $parts);
+		$command = $this->getApplication()->getCommand('config:set');
 
-		if (strpos($output, "Configuration set") !== false)
+		$command->setOptions('offline=true');
+
+		$returnCode = $command->execute();
+
+		if ($returnCode === 0)
 		{
 			$this->ioStyle->success("Successfully set site to offline");
+
+			return 0;
 		}
 
-		return 0;
+
+		return 1;
 	}
 
 	/**

--- a/libraries/src/Console/SiteDownCommand.php
+++ b/libraries/src/Console/SiteDownCommand.php
@@ -28,6 +28,18 @@ class SiteDownCommand extends AbstractCommand
 	private $ioStyle;
 
 	/**
+	 * Return code if site:down failed
+	 * @since 4.0
+	 */
+	const SITE_DOWN_FAILED = 1;
+
+	/**
+	 * Return code if site:down was successful
+	 * @since 4.0
+	 */
+	const SITE_DOWN_SUCCESSFUL = 0;
+
+	/**
 	 * Configures the IO
 	 *
 	 * @return void
@@ -60,11 +72,11 @@ class SiteDownCommand extends AbstractCommand
 		{
 			$this->ioStyle->success("Successfully set site to offline");
 
-			return 0;
+			return self::SITE_DOWN_SUCCESSFUL;
 		}
 
 
-		return 1;
+		return self::SITE_DOWN_FAILED;
 	}
 
 	/**

--- a/libraries/src/Console/SiteDownCommand.php
+++ b/libraries/src/Console/SiteDownCommand.php
@@ -50,7 +50,7 @@ class SiteDownCommand extends AbstractCommand
 	{
 		$this->configureIO();
 
-		exec('php cli/joomla.php config:set offline true', $parts);
+		exec('php cli/joomla.php config:set offline=true', $parts);
 		$output = implode("\n", $parts);
 
 		if (strpos($output, "Configuration set") !== false)

--- a/libraries/src/Console/SiteUpCommand.php
+++ b/libraries/src/Console/SiteUpCommand.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Console;
+
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\Console\AbstractCommand;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Console command wrapper for getting the site into offline mode
+ *
+ * @since  4.0.0
+ */
+class SiteUpCommand extends AbstractCommand
+{
+	/**
+	 * SymfonyStyle Object
+	 * @var SymfonyStyle
+	 * @since 4.0
+	 */
+	private $ioStyle;
+
+	/**
+	 * Configures the IO
+	 *
+	 * @return void
+	 *
+	 * @since 4.0
+	 */
+	private function configureIO()
+	{
+		$this->ioStyle = new SymfonyStyle($this->getApplication()->getConsoleInput(), $this->getApplication()->getConsoleOutput());
+	}
+
+	/**
+	 * Execute the command.
+	 *
+	 * @return  integer  The exit code for the command.
+	 *
+	 * @since   4.0.0
+	 */
+	public function execute(): int
+	{
+		$this->configureIO();
+
+		exec('php cli/joomla.php config:set offline false', $parts);
+		$output = implode("\n", $parts);
+
+		if (strpos($output, "Configuration set") !== false)
+		{
+			$this->ioStyle->success("Website is now online");
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Initialise the command.
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0.0
+	 */
+	protected function initialise()
+	{
+		$this->setName('site:up');
+		$this->setDescription('Puts the site into online mode');
+
+		$help = "The <info>%command.name%</info> Puts the site into online mode
+				\nUsage: <info>php %command.full_name%</info>";
+
+		$this->setHelp($help);
+	}
+}

--- a/libraries/src/Console/SiteUpCommand.php
+++ b/libraries/src/Console/SiteUpCommand.php
@@ -28,6 +28,18 @@ class SiteUpCommand extends AbstractCommand
 	private $ioStyle;
 
 	/**
+	 * Return code if site:up failed
+	 * @since 4.0
+	 */
+	const SITE_UP_FAILED = 1;
+
+	/**
+	 * Return code if site:up was successful
+	 * @since 4.0
+	 */
+	const SITE_UP_SUCCESSFUL = 0;
+
+	/**
 	 * Configures the IO
 	 *
 	 * @return void
@@ -60,11 +72,11 @@ class SiteUpCommand extends AbstractCommand
 		{
 			$this->ioStyle->success("Website is now online");
 
-			return 0;
+			return self::SITE_UP_SUCCESSFUL;
 		}
 
 
-		return 1;
+		return self::SITE_UP_FAILED;
 	}
 
 	/**

--- a/libraries/src/Console/SiteUpCommand.php
+++ b/libraries/src/Console/SiteUpCommand.php
@@ -50,15 +50,21 @@ class SiteUpCommand extends AbstractCommand
 	{
 		$this->configureIO();
 
-		exec('php cli/joomla.php config:set offline false', $parts);
-		$output = implode("\n", $parts);
+		$command = $this->getApplication()->getCommand('config:set');
 
-		if (strpos($output, "Configuration set") !== false)
+		$command->setOptions('offline=false');
+
+		$returnCode = $command->execute();
+
+		if ($returnCode === 0)
 		{
 			$this->ioStyle->success("Website is now online");
+
+			return 0;
 		}
 
-		return 0;
+
+		return 1;
 	}
 
 	/**

--- a/tests/system/suites/console/GetConfigurationCommandTest.php
+++ b/tests/system/suites/console/GetConfigurationCommandTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @package    Joomla.SystemTest
+ *
+ * @copyright  Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+class GetConfigurationCommandTest extends \PHPUnit\Framework\TestCase
+{
+
+	/**
+	 * @testdox Output from  `php cli/joomla.php help config:get` contains usage instructions
+	 *
+	 * @since 4.0
+	 *
+	 * @return void
+	 */
+	public function testIfCommandOutputContainsUsageInformation()
+	{
+		exec('php cli/joomla.php help config:get', $parts);
+		$parts = array_flip($parts);
+		$this->assertArrayHasKey("Usage:", $parts, 'Message should contain usage instructions');
+	}
+
+	/**
+	 * Tests if command did not return a value for the option provided when option doesn't exist
+	 *
+	 * @since 4.0
+	 *
+	 * @return void
+	 */
+	public function testIfCommandDidNotFoundTheConfigOption()
+	{
+		exec('php cli/joomla.php config:get qwerty', $parts);
+		$output = implode("\n", $parts);
+		$this->assertContains("Can't find option *qwerty* in configuration list", $output);
+	}
+
+	/**
+	 * Test if command returns the value of the option provided
+	 *
+	 * @since 4.0
+	 *
+	 * @return void
+	 */
+	public function testIfCommandFoundTheConfigOption()
+	{
+		exec('php cli/joomla.php config:get sitename', $parts);
+		$output = implode("\n", $parts);
+		$this->assertContains("Option", $output);
+		$this->assertContains("Value", $output);
+		$this->assertContains("sitename", $output);
+	}
+}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
- Added `config:get` command
- Added `config:set` command (now supports multiple setting of options)
- Added `--group` option for logically grouped options
- Added `site:down` command
- Added `site:up` command

### Testing Instructions
These commands can run like this:

 `php cli/joomla.php config:get dbprefix` 

`php cli/joomla.php config:set offline=true mailer=mailer`

`php cli/joomla.php config:get --group=mail` 

`php cli/joomla.php site:down`

`php cli/joomla.php site:up` 


### Expected result
Displays result based on command
